### PR TITLE
 Explicitly declare and isolate dependencies

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -2,9 +2,9 @@
 binary "https://kawoou.kr/ReactorKit-Carthage/ReactorKit-Static"
 
 # Rx
-github "ReactiveX/RxSwift"
-github "RxSwiftCommunity/RxOptional"
-github "RxSwiftCommunity/RxDataSources"
+github "ReactiveX/RxSwift" "4.3.1"
+github "RxSwiftCommunity/RxOptional" "3.5.0"
+github "RxSwiftCommunity/RxDataSources" "3.1.0"
 github "kawoou/RxValidator" "94750bdcd89b8d2f84682c949f6893b0d44a37e1"
 
 # Database
@@ -12,18 +12,18 @@ binary "https://github.com/kawoou/DeliTodo/raw/realm/Realm"
 #github "realm/realm-cocoa"
 
 # Logging
-github "SwiftyBeaver/SwiftyBeaver"
+github "SwiftyBeaver/SwiftyBeaver" "1.6.1"
 
 # Deeplink
-github "button/DeepLinkKit"
+github "button/DeepLinkKit" "1.5.0"
 
 # UI
-github "SnapKit/SnapKit"
-github "cruisediary/Gradients"
-github "raulriera/TextFieldEffects"
-github "SwipeCellKit/SwipeCellKit"
-github "Daltron/NotificationBanner"
+github "SnapKit/SnapKit" "4.0.1"
+github "cruisediary/Gradients" "0.1.4"
+github "raulriera/TextFieldEffects" "1.5.0"
+github "SwipeCellKit/SwipeCellKit" "2.5.0"
+github "Daltron/NotificationBanner" "1.7.3"
 
 # Test
-github "Quick/Quick"
-github "Quick/Nimble"
+github "Quick/Quick" "v1.3.2"
+github "Quick/Nimble" "v7.3.1"

--- a/Podfile
+++ b/Podfile
@@ -4,24 +4,24 @@ target 'DeliTodo' do
   use_frameworks!
 
   # Binary
-  pod 'Deli'
-  pod 'SwiftLint'
-  pod 'SwiftGen'
-  pod 'LicensePlist'
+  pod 'Deli', '= 0.6.0'
+  pod 'SwiftLint', '= 0.27.0'
+  pod 'SwiftGen', '= 6.0.1'
+  pod 'LicensePlist', '= 1.8.8'
 
   # Crashlytics
-  pod 'Fabric'
-  pod 'Crashlytics'
+  pod 'Fabric', '= 1.7.13'
+  pod 'Crashlytics', '= 3.10.9'
 
   # Firebase
-  pod 'FirebaseCore'
-  pod 'FirebaseAuth'
-  pod 'FirebaseAnalytics'
-  pod 'FirebaseDatabase'
+  pod 'FirebaseCore', '= 5.1.4'
+  pod 'FirebaseAuth', '= 5.0.4'
+  pod 'FirebaseAnalytics', '= 5.2.0'
+  pod 'FirebaseDatabase', '= 5.0.3'
 
   # Analytics
-  pod 'Umbrella'
-  pod 'Umbrella/Firebase'
+  pod 'Umbrella', '= 0.7.1'
+  pod 'Umbrella/Firebase', '= 0.7.1'
 
   target 'DeliTodoTests' do
     inherit! :search_paths

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,18 +70,18 @@ PODS:
     - Umbrella/Core
 
 DEPENDENCIES:
-  - Crashlytics
-  - Deli
-  - Fabric
-  - FirebaseAnalytics
-  - FirebaseAuth
-  - FirebaseCore
-  - FirebaseDatabase
-  - LicensePlist
-  - SwiftGen
-  - SwiftLint
-  - Umbrella
-  - Umbrella/Firebase
+  - Crashlytics (= 3.10.9)
+  - Deli (= 0.6.0)
+  - Fabric (= 1.7.13)
+  - FirebaseAnalytics (= 5.2.0)
+  - FirebaseAuth (= 5.0.4)
+  - FirebaseCore (= 5.1.4)
+  - FirebaseDatabase (= 5.0.3)
+  - LicensePlist (= 1.8.8)
+  - SwiftGen (= 6.0.1)
+  - SwiftLint (= 0.27.0)
+  - Umbrella (= 0.7.1)
+  - Umbrella/Firebase (= 0.7.1)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
@@ -126,6 +126,6 @@ SPEC CHECKSUMS:
   SwiftLint: 3207c1faa2240bf8973b191820a116113cd11073
   Umbrella: 90c8dea533add4a072dfd48fbc3a53f62c6e0716
 
-PODFILE CHECKSUM: 5582234720b4452eba5b15a6a3ec0452b7b5cdbe
+PODFILE CHECKSUM: 358e36c4c56e31f25cc30e730aab9bcc83f581c0
 
 COCOAPODS: 1.6.0.beta.1


### PR DESCRIPTION
#### Reference [ios-factor](https://ios-factor.com/dependencies)
> By specifying the exact dependencies you can re-trigger a build from 6 months ago, knowing that it will succeed as it will use the same version of Xcode, CocoaPods and Swift.

Today DeliTodo build failed because dependencies after bumping Gradients version 0.1.4 to 0.2.1

#### CHANGELOG
```swift
// 0.1.4
Gradients.nightSky.layer()

// 0.2.x
Gradients.nightSky.layer
```

Explicitly declare and isolate dependencies for
- Carthage 
- CocoaPods 